### PR TITLE
Show theme selector also in docs tab.

### DIFF
--- a/src/register.tsx
+++ b/src/register.tsx
@@ -8,7 +8,7 @@ addons.register(ADDON_ID, api => {
   addons.add(ADDON_ID, {
     title: 'Themes',
     type: types.TOOL,
-    match: ({ viewMode }) => viewMode === 'story',
+    match: ({ viewMode }) => viewMode === 'story' || viewMode === 'docs',
     render: () => <ThemeSelector api={api} />,
   });
 });


### PR DESCRIPTION
This makes the addon visible when the docs tab is active, similar to https://github.com/hipstersmoothie/storybook-dark-mode. This is useful because these addons combined allow you to test every theme variation.