### PR TITLE
task: Remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,6 @@
     "shelljs": "^0.8.3",
     "typescript": "^3.7.5"
   },
-  "peerDependencies": {
-    "react": "*",
-    "svelte": "*",
-    "vue": "*"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,17 @@
     "shelljs": "^0.8.3",
     "typescript": "^3.7.5"
   },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "svelte": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
@tonai 
Hello and thank you for this great Storybook addon!!

I'm interested in removing the peerDependencies requirement from using this repo.  It seems wrong to have to add, for example, `vue` as a dependency to my storybook style guide when I am using either `svelte` or `react`.

**Update: Instead of removing, I changed it to `peerDependenciesMeta`.  Thoughts?  See [yarn docs](https://classic.yarnpkg.com/en/docs/package-json/#toc-peerdependenciesmeta)**


This shows up when doing a yarn/npm install:
![Screen Shot 2020-12-02 at 5 00 57 PM](https://user-images.githubusercontent.com/1102747/100946501-b5006800-34c0-11eb-828a-8dff5fddee7e.png)

If there is a better way to communicate the intent of these peer dependencies where only one of them is needed I'd be happy to add that.

Much thanks!