### PR TITLE
Allow to set target element to apply classes to

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The `themes` parameter also accept an object with the following properties:
 * `disable` (`boolean` - optional): Disable the addon for a story
 * `Decorator` (`Component` - optional): A component to use as the decorator component ([see below](#custom-decorator) for more information)
 * `onChange` (`(themeName: Theme) => void` - optional): A callback that will be executed when the theme changes
+* `target` (`string` - optional): Target element selected with `document.querySelector()` to which classes are applied. Defaults to `body`, `root` if classes should be applied to `documentElement`.
 
 ## Configuration
 
@@ -184,7 +185,7 @@ withText.story = {
 
 ## Usage with decorator
 
-By default the classes will be added to the `body` element.
+By default the classes will be added to the `body` element or the element configured with `target`.
 
 But in this case your theme will not be visible by other addons (like [@storybook/addon-storyshots](https://github.com/storybookjs/storybook/tree/next/addons/storyshots)).
 

--- a/src/manager/ThemeSelector.tsx
+++ b/src/manager/ThemeSelector.tsx
@@ -37,7 +37,7 @@ const createThemeSelectorItem = memoize(1000)(
 
 const getDisplayableState = memoize(10)(
   (props: ThemeToolProps, state: ThemeToolState, change) => {
-    const { clearable, list, default: defaultTheme } = getConfigFromApi(props.api);
+    const { clearable, list, target, default: defaultTheme } = getConfigFromApi(props.api);
     const selectedThemeName = getSelectedThemeName(list, defaultTheme, state.selected);
 
     let availableThemeSelectorItems: ThemeSelectorItem[] = [];
@@ -63,6 +63,7 @@ const getDisplayableState = memoize(10)(
       items: availableThemeSelectorItems,
       selectedTheme,
       themes: list,
+      target,
     };
   }
 );
@@ -118,7 +119,7 @@ export class ThemeSelector extends Component<ThemeToolProps, ThemeToolState> {
 
   render() {
     const { decorator, expanded } = this.state;
-    const { items, selectedTheme, themes } = getDisplayableState(
+    const { items, selectedTheme, target, themes } = getDisplayableState(
       this.props,
       this.state,
       this.change
@@ -127,7 +128,7 @@ export class ThemeSelector extends Component<ThemeToolProps, ThemeToolState> {
     return items.length ? (
       <Fragment>
         {!decorator && (
-          <ThemeStory iframeId={iframeId} selectedTheme={selectedTheme} themes={themes} />
+          <ThemeStory iframeId={iframeId} selectedTheme={selectedTheme} target={target} themes={themes} />
         )}
         <WithTooltip
           placement="top"

--- a/src/manager/ThemeStory.tsx
+++ b/src/manager/ThemeStory.tsx
@@ -8,26 +8,41 @@ interface Props {
   iframeId: string;
   selectedTheme: Theme;
   themes: Theme[];
+  target?: string;
 }
 
 export const ThemeStory: React.FC<Props> = (props) => {
-  const { iframeId, selectedTheme, themes } = props;
+  const { iframeId, selectedTheme, target, themes } = props;
 
   useEffect(() => {
+    let targetEl: HTMLElement;
     const iframe = document.getElementById(iframeId);
     if (!iframe) {
       return null;
     }
 
     const iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
-    const { body } = iframeDocument;
+
+    switch(target) {
+        case 'root':
+        case 'html':
+          targetEl = iframeDocument.documentElement;
+        break;
+        default:
+          if(!target || target === 'body') {
+            targetEl = iframeDocument.body;
+          } else {
+            targetEl = iframeDocument.documentElement.querySelector(target);
+          }
+        break;
+    }
 
     // Add selected theme class(es).
     if (selectedTheme && selectedTheme.class) {
       if (typeof selectedTheme.class === 'string') {
-        body.classList.add(selectedTheme.class)
+        targetEl.classList.add(selectedTheme.class)
       } else { // string[]
-        body.classList.add(...selectedTheme.class)
+        targetEl.classList.add(...selectedTheme.class)
       }
     }
 
@@ -35,9 +50,9 @@ export const ThemeStory: React.FC<Props> = (props) => {
       .filter(theme => theme.class)
       .forEach(theme => {
         if (typeof theme.class === 'string') {
-          body.classList.remove(theme.class)
+          targetEl.classList.remove(theme.class)
         } else { // string[]
-          body.classList.remove(...theme.class)
+          targetEl.classList.remove(...theme.class)
         }
       });
   });

--- a/src/models/ThemeConfig.ts
+++ b/src/models/ThemeConfig.ts
@@ -6,5 +6,6 @@ export interface ThemeConfig {
   Decorator?: Decorator,
   default?: string,
   list: Theme[],
-  onChange?: (themeName: Theme) => void
+  onChange?: (themeName: Theme) => void,
+  target?: string
 }


### PR DESCRIPTION
So far classes are applied to `body` by default, this PR introduces a new config `target` which allows to specify the target element to which classes are applied.