### PR TITLE
Use a different icon compared to the backgrounds addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+#### Added
+- Add support for custom icon via config. ([@dhruvkb](https://github.com/https://github.com/norin89) in [#64](https://github.com/tonai/storybook-addon-themes/pull/64))
 
 ## [6.1.0] - 2021-04-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each `Theme` is an object with the following properties:
 
 The `themes` parameter also accept an object with the following properties:
 
+* `icon` (`string` - optional - default is `'mirror'`): The icon to use for the addon in the toolbar ([options](https://github.com/storybookjs/design-system/blob/b4524b4cdeed9a7d4d4e8d516bffcba59d14e4e0/src/components/shared/icons.ts))
 * `default` (`string` - optional): Name of theme selected by default
 * `list` (`Theme[]` - required): The list of themes
 * `clearable` (`boolean` - optional - default is `true`): Can the user clear the selected theme ?

--- a/src/manager/ThemeSelector.tsx
+++ b/src/manager/ThemeSelector.tsx
@@ -145,7 +145,7 @@ export class ThemeSelector extends Component<ThemeToolProps, ThemeToolState> {
             active={selectedTheme}
             title="Change the theme of the preview"
           >
-            <Icons icon="photo" />
+            <Icons icon="mirror" />
           </IconButton>
         </WithTooltip>
       </Fragment>

--- a/src/manager/ThemeSelector.tsx
+++ b/src/manager/ThemeSelector.tsx
@@ -37,7 +37,7 @@ const createThemeSelectorItem = memoize(1000)(
 
 const getDisplayableState = memoize(10)(
   (props: ThemeToolProps, state: ThemeToolState, change) => {
-    const { clearable, list, target, default: defaultTheme } = getConfigFromApi(props.api);
+    const { clearable, icon, list, target, default: defaultTheme } = getConfigFromApi(props.api);
     const selectedThemeName = getSelectedThemeName(list, defaultTheme, state.selected);
 
     let availableThemeSelectorItems: ThemeSelectorItem[] = [];
@@ -60,6 +60,7 @@ const getDisplayableState = memoize(10)(
     }
 
     return {
+      icon,
       items: availableThemeSelectorItems,
       selectedTheme,
       themes: list,
@@ -119,7 +120,7 @@ export class ThemeSelector extends Component<ThemeToolProps, ThemeToolState> {
 
   render() {
     const { decorator, expanded } = this.state;
-    const { items, selectedTheme, target, themes } = getDisplayableState(
+    const { icon, items, selectedTheme, target, themes } = getDisplayableState(
       this.props,
       this.state,
       this.change
@@ -145,7 +146,7 @@ export class ThemeSelector extends Component<ThemeToolProps, ThemeToolState> {
             active={selectedTheme}
             title="Change the theme of the preview"
           >
-            <Icons icon="mirror" />
+            <Icons icon={icon} />
           </IconButton>
         </WithTooltip>
       </Fragment>

--- a/src/models/ThemeConfig.ts
+++ b/src/models/ThemeConfig.ts
@@ -2,6 +2,7 @@ import { Decorator } from './Decorator';
 import { Theme } from './Theme';
 
 export interface ThemeConfig {
+  icon?: string,
   clearable?: boolean,
   Decorator?: Decorator,
   default?: string,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -5,6 +5,7 @@ import { Theme, ThemeConfig } from './models';
 
 const defaultOptions: ThemeConfig = {
   clearable: true,
+  icon: 'mirror',
   list: []
 };
 


### PR DESCRIPTION
Fixes #50.

This PR changes the icon used by the add-on from `photo` to `mirror` as the photo icon is already used by the official, bundled backgrounds add-on.

Before:
<img width="90" alt="Screenshot 2021-07-13 at 9 10 29 AM" src="https://user-images.githubusercontent.com/16580576/125386600-2f2f8e00-e3ba-11eb-9e6f-c25974b26cc2.png">

After:
<img width="99" alt="Screenshot 2021-07-13 at 9 10 56 AM" src="https://user-images.githubusercontent.com/16580576/125386642-3eaed700-e3ba-11eb-84ab-83a141c53882.png">

The mirror icon made personal sense to me as I was using this add-on to manage light and dark themes but there are a lot of other icons in [this list](https://5ccbc373887ca40020446347-qvjajxnkih.chromatic.com/?path=/story/icon--labels) to choose from, which is why accepting it as a config option would be awesome.

## References:

- Changes retrofitted from fork: https://github.com/dhruvkb/storybook-addon-themes. 
- Example config: https://github.com/dhruvkb/seeelaye/blob/6bd764f9e0f74341b0201c50cc65001f361a9b07/.storybook/preview.ts#L35
- Live demo of custom icon: https://seeelaye.vercel.app/